### PR TITLE
Logs, script from quick fix of padded metadata md5 collisions.

### DIFF
--- a/actions/resolve-md5-collisions/DESCRIPTION.md
+++ b/actions/resolve-md5-collisions/DESCRIPTION.md
@@ -1,0 +1,145 @@
+# Resolve md5 Collisions
+
+## Purpose
+
+An md5 sum describing the first MB of a data file is stored in the metadata database 
+and used to detect updates to the file. In some cases where a netCDF file is generated
+with extra header space to support faster updating of the headers, the first MB may
+actually be identical across two different data files that share a model, variable, and
+period; differing only by emissions scenario.
+
+A file whose first MB is identical to a file already in the database, but which has
+a different unique ID (model, period, emissions scenario, run, and variable),
+cannot be indexed and yields the following error message:
+
+```
+2018-03-05 15:19:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:19:37 ERROR: Encountered an unanticipated case:
+2018-03-05 15:19:37 ERROR: id_match.id = None
+2018-03-05 15:19:37 ERROR: hash_match.id = 13
+2018-03-05 15:19:37 ERROR: filename_match.id = None
+2018-03-05 15:19:37 ERROR: old_filename_exists = True; normalized_filenames_match = False; index_up_to_date = True
+2018-03-05 15:19:37 ERROR: Traceback (most recent call last):
+  File "/home/lzeman/Code/modelmeta-generic/modelmeta/venv/lib/python3.5/site-packages/mm_cataloguer/index_netcdf.py", line 1060, in index_netcdf_file
+    data_file = find_update_or_insert_cf_file(session, cf)
+  File "/home/lzeman/Code/modelmeta-generic/modelmeta/venv/lib/python3.5/site-packages/mm_cataloguer/index_netcdf.py", line 1045, in find_update_or_insert_cf_file
+    raise ValueError('Unanticipated case. See log for details.')
+ValueError: Unanticipated case. See log for details.
+```
+
+Long term, the correct solution is to update the database and reindex all files to take
+the md5 sum of a longer section of the file, perhap 10MB. Short term, this script
+was used to remove the empty space from the headers of a file for file-by-file
+resolution of the md5 collision for high-priority files we needed indexed right away
+(precipitation climdexes).
+
+The script simply copies every dimension, variable, and attribute from one netCDF
+file to another. You'd expect there to be a pre-existing netCDF tool that does
+this, but `nccopy` faithfully copies header padding, while `cdo copy` removes 
+header padding but makes other unwanted changes.
+
+## Procedure
+
+1. Run the indexing script on the directory containing the md5 hash collision files, redirecting output to a logfile.
+`python scripts/index_netcdf -d postgresql://whateverdatabase /path/to/files/dtrETCCDI_*.nc &> dtr.log`
+
+2. Grep the logfile for the error message to get a list of the affected files.
+`grep -B1 "unanticipated" dtr.log`
+
+3. Move the affected files to their own directory.
+`mv /path/to/files/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_*.nc /path/to/files/md5_collisions/`
+
+4. Run the de-padding script on the files, placing results in a sub-directory.
+`python strip_metadata_padding.py /path/to/files/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_*.nc  /path/to/files/md5_collisions/compressed`
+
+5. Re-index the files, and add to ensembles as needed.
+`python scripts/index_netcdf -d postgresql://whateverdatabase /path/to/files/md5_collisions/compressed/*.nc`
+
+## Datafiles Processed
+dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+
+## Datafiles Not Processed
+Other climdex files with different variables are also affected by this issue. 
+Since those files were not needed urgently for a project, they have not yet been 
+processed in this way. Estimated number of files that are not currently indexed and
+cannot be indexed due to md5 collision, as of April 10, 2018:
+
+* tn10pETCCDI - 72 datafiles
+* tn90pETCCDI - 72 datafiles
+* tnnETCCDI - 24 datafiles
+* tnxETCCDI - 24 datafiles
+* tx10pETCCDI - 48 datafiles
+* tx90pETCCDI - 48 datafiles
+* txnETCCDI - 48 datafiles
+* txxETCCDI - 48 datafiles

--- a/actions/resolve-md5-collisions/index_collision_logs/dtr-collisions.txt
+++ b/actions/resolve-md5-collisions/index_collision_logs/dtr-collisions.txt
@@ -1,0 +1,86 @@
+2018-03-05 15:19:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:19:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:19:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:19:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:19:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:19:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:19:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:19:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:19:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:19:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:19:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:19:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:19:39 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:19:40 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:19:40 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:19:40 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:19:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:19:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:19:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_HadGEM2-CC_historical+rcp85_r1i1p1_19610101-19901230.nc
+2018-03-05 15:19:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_HadGEM2-CC_historical+rcp85_r1i1p1_19710101-20001230.nc
+2018-03-05 15:19:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_HadGEM2-CC_historical+rcp85_r1i1p1_19810101-20101230.nc
+2018-03-05 15:19:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_HadGEM2-CC_historical+rcp85_r1i1p1_20100101-20391230.nc
+2018-03-05 15:19:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_HadGEM2-CC_historical+rcp85_r1i1p1_20400101-20691230.nc
+2018-03-05 15:19:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:19:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:19:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:19:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:19:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:19:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:19:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/dtrETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:19:45 ERROR: Encountered an unanticipated case:

--- a/actions/resolve-md5-collisions/index_collision_logs/rx1day-collisions.txt
+++ b/actions/resolve-md5-collisions/index_collision_logs/rx1day-collisions.txt
@@ -1,0 +1,71 @@
+2018-03-05 15:22:01 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:22:01 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:01 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:22:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:22:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:22:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:22:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:22:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:05 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:22:05 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:06 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:22:06 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:06 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:22:06 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:06 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:22:06 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:06 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:22:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:22:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:22:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:22:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:22:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:22:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:22:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:22:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:22:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:22:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:22:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:28 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:22:28 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:28 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:22:28 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:22:28 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx1dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:22:28 ERROR: Encountered an unanticipated case:

--- a/actions/resolve-md5-collisions/index_collision_logs/rx5day-collisions.txt
+++ b/actions/resolve-md5-collisions/index_collision_logs/rx5day-collisions.txt
@@ -1,0 +1,71 @@
+2018-03-05 15:25:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:25:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:25:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:25:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:32 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:25:32 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:32 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:25:32 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:32 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:25:32 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:34 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:25:34 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:34 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:25:35 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:35 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:25:35 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:35 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:25:35 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:35 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:25:35 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:35 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:25:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:25:40 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:25:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:25:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:25:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:25:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:25:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:25:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:25:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:25:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:25:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:25:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:25:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/rx5dayETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:25:55 ERROR: Encountered an unanticipated case:

--- a/actions/resolve-md5-collisions/index_collision_logs/tn10-collisions.txt
+++ b/actions/resolve-md5-collisions/index_collision_logs/tn10-collisions.txt
@@ -1,0 +1,215 @@
+2018-03-05 15:29:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:29:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:29:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:29:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:29:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:29:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:29:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:10 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:29:10 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:29:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:29:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:29:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:29:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:29:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:29:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:29:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:29:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:29:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:18 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:29:18 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:18 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:29:18 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:29:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:29:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:29:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:29:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:32 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:29:32 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:32 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:29:32 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:29:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:29:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:29:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:29:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:29:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:29:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:59 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:29:59 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:29:59 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:30:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:30:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:30:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:30:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:30:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:30:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:30:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:30:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:30:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:30:11 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:11 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:30:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:30:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:30:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:30:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:30:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:30:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:30:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:30:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:31:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:31:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:31:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:31:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:31:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:31:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:31:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:31:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:31:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:31:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:31:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:31:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:15 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:31:15 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:15 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:31:16 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:16 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:31:16 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:16 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:31:16 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:16 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:31:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:31:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:31:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:31:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:31:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:31:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:31:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:31:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:31:37 ERROR: Encountered an unanticipated case:

--- a/actions/resolve-md5-collisions/index_collision_logs/tn90-collisions.txt
+++ b/actions/resolve-md5-collisions/index_collision_logs/tn90-collisions.txt
@@ -1,0 +1,215 @@
+2018-03-05 15:32:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:32:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:32:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:32:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:32:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:32:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:32:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:32:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:32:49 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:49 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:32:49 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:49 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:32:49 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:49 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:32:49 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:50 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:32:50 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:32:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:32:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:32:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:32:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:32:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:32:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:32:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:33:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:33:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:33:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:33:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:10 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:33:10 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:10 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:33:10 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:33:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:33:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:33:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:33:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:33:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:33:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:43 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:33:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:43 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:33:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:43 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:33:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:43 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:33:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:33:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:33:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:33:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:33:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:33:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:55 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:33:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:33:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:33:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:33:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:34:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:34:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:34:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:34:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:34:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:34:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:34:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:34:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:34:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:34:49 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:49 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:34:49 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:49 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:34:49 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:34:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:34:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:34:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:34:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:34:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:34:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:34:55 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:35:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:35:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:35:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:35:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:35:04 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:04 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:35:04 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:25 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:35:26 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:26 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:35:26 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:26 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:35:26 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:26 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:35:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:35:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:35:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tn90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:35:27 ERROR: Encountered an unanticipated case:

--- a/actions/resolve-md5-collisions/index_collision_logs/tnn-collisions.txt
+++ b/actions/resolve-md5-collisions/index_collision_logs/tnn-collisions.txt
@@ -1,0 +1,71 @@
+2018-03-05 15:36:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:36:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:36:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:36:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:36:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:36:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:36:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:57 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:36:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:57 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:36:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:57 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:36:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:58 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:36:58 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:58 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:36:58 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:36:58 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:36:58 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:37:02 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:02 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:37:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:37:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:37:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:37:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:37:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:37:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:37:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:37:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:17 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:37:17 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:18 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:37:18 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:37:18 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:37:18 ERROR: Encountered an unanticipated case:

--- a/actions/resolve-md5-collisions/index_collision_logs/tnx-collisions.txt
+++ b/actions/resolve-md5-collisions/index_collision_logs/tnx-collisions.txt
@@ -1,0 +1,71 @@
+2018-03-05 15:40:43 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:40:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:43 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:40:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:43 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:40:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:40:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:40:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:40:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:40:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:40:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:40:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:40:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:40:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:40:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:52 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:40:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:40:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:40:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:40:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:40:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:40:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:40:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:41:04 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:41:04 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:41:04 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:41:04 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:41:04 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:41:04 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:41:04 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:41:05 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:41:05 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:41:05 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:41:05 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tnxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:41:05 ERROR: Encountered an unanticipated case:

--- a/actions/resolve-md5-collisions/index_collision_logs/tx-multi-collisions.txt
+++ b/actions/resolve-md5-collisions/index_collision_logs/tx-multi-collisions.txt
@@ -1,0 +1,575 @@
+2018-03-05 15:45:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:45:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:45:03 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:03 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:45:04 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:04 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:45:04 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:04 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:45:04 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:04 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:45:05 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:45:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:45:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:45:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:45:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:45:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:45:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:45:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:45:12 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:12 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:45:13 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:13 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:45:13 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:13 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:45:13 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:13 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:45:13 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:26 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:45:26 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:45:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:45:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:45:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:45:27 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:27 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:45:28 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:45:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:45:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:45:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:45:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:45:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:45:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:45:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:45:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:45:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:45:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:45:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:45:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:45:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:46:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:46:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:46:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:46:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:10 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:46:10 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:10 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:46:10 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:39 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:46:40 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:46:40 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:46:40 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:46:40 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:40 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:46:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:46:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:46:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:46:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:46:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:46:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:46:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:46:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:46:59 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:47:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:47:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:47:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:47:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:47:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:01 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:47:01 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:47:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:47:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:47:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:47:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:47:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:09 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:47:09 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:29 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:47:29 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:29 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:47:29 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:47:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:47:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:47:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx10pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:47:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:47:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:47:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:41 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:47:41 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:47:42 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:47:42 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:47:42 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:47:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:47:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:47:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:47:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:45 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:47:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:46 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:47:46 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:47:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:47:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:47:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:47:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:47:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:47:52 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:47:52 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:48:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:48:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:48:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:07 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:48:07 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:48:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:08 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:48:08 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:29 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:48:29 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:29 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:48:29 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:48:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:48:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:48:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:48:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:48:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:48:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:48:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:48:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:39 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:48:39 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:39 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:48:39 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:48:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:48:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:48:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:48:51 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:51 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:48:52 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:48:52 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:48:52 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:29 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:49:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:49:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:49:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:49:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:30 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:49:30 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:31 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_mClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:49:31 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:49:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:49:47 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:47 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:49:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:49:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:49:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:48 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:49:48 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:52 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:49:52 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:52 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:49:52 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:52 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:49:52 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:52 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:49:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:49:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:49:53 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:49:53 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:50:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:50:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:00 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:50:00 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:01 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:50:01 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:01 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:50:01 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:01 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:50:01 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:20 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:50:20 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:20 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:50:20 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:21 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:50:21 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:21 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:50:21 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:21 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:50:21 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:21 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/tx90pETCCDI_sClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:50:21 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:33 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:50:33 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:33 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:50:33 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:33 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:50:33 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:33 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:50:33 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:33 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:50:33 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:34 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:50:34 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:50:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:50:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:50:36 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:36 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:50:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:50:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:50:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:50:42 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:50:42 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:50:42 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:50:42 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:50:42 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:42 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:50:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:50:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:54 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:50:54 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:50:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:50:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:57 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:50:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:50:57 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txnETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:50:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:34 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:53:34 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:34 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:53:34 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:34 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:53:34 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:34 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:53:35 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:35 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:53:35 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:35 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CanESM2_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:53:35 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19610101-19901231.nc
+2018-03-05 15:53:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19710101-20001231.nc
+2018-03-05 15:53:37 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:37 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_19810101-20101231.nc
+2018-03-05 15:53:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20100101-20391231.nc
+2018-03-05 15:53:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20400101-20691231.nc
+2018-03-05 15:53:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:38 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CCSM4_historical+rcp85_r2i1p1_20700101-20991231.nc
+2018-03-05 15:53:38 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:43 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19610101-19901231.nc
+2018-03-05 15:53:43 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19710101-20001231.nc
+2018-03-05 15:53:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_19810101-20101231.nc
+2018-03-05 15:53:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20100101-20391231.nc
+2018-03-05 15:53:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20400101-20691231.nc
+2018-03-05 15:53:44 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:44 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_CNRM-CM5_historical+rcp85_r1i1p1_20700101-20991231.nc
+2018-03-05 15:53:45 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19610101-19901231.nc
+2018-03-05 15:53:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19710101-20001231.nc
+2018-03-05 15:53:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:56 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_19810101-20101231.nc
+2018-03-05 15:53:56 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:57 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20100101-20391231.nc
+2018-03-05 15:53:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:57 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20400101-20691231.nc
+2018-03-05 15:53:57 ERROR: Encountered an unanticipated case:
+--
+2018-03-05 15:53:57 INFO: Processing file: /storage/data/projects/comp_support/climate_explorer_data_prep/climatological_means/climdex/txxETCCDI_aClim_BCCAQ_MRI-CGCM3_historical+rcp45_r1i1p1_20700101-20991231.nc
+2018-03-05 15:53:57 ERROR: Encountered an unanticipated case:

--- a/actions/resolve-md5-collisions/strip_metadata_padding.py
+++ b/actions/resolve-md5-collisions/strip_metadata_padding.py
@@ -1,0 +1,56 @@
+#! python
+'''This script copies all dimensions, variables, and attributes from a netCDF
+file into a new file. It differs from nccopy or plain old unix cp by NOT copying
+allocated but unused metadata space, so it can be used to produce files without
+metadata expansion space if further metadata changes are not anticipated.'''
+
+import argparse
+import os.path
+import sys
+import time
+from pathlib import Path
+from netCDF4 import Dataset
+
+parser = argparse.ArgumentParser(description='Create a copy of a netCDF file, stripping unused metadata space')
+parser.add_argument('source_file', metavar='source', help='source netCDF file')
+parser.add_argument('dest_dir', metavar='copydir', help='destination directory')
+
+args = parser.parse_args()
+
+#Make sure we won't be overwriting the destination.
+if not Path(args.dest_dir).is_dir():
+    print("ERROR: {} is not a directory".format(args.dest_dir))
+    sys.exit()
+    
+dest = args.dest_dir + '/' + args.source_file.split('/')[-1]
+
+if Path(dest).is_file():
+    print("ERROR: {} already exists".format(dest))
+    sys.exit()
+
+source = Dataset(args.source_file, "r")
+dest = Dataset(dest, "w")
+
+#dimensions
+for dim in source.dimensions:
+    print("Now copying dimension {}".format(dim))
+    size = None if source.dimensions[dim].isunlimited() else len(source.dimensions[dim])
+    dest.createDimension(dim, size)
+
+#variables
+for var in source.variables:
+    print("Now copying variable {}".format(var))
+    dest.createVariable(var, source.variables[var].dtype, source.variables[var].dimensions)
+    dest.variables[var].setncatts(source.variables[var].__dict__)
+    dest.variables[var][:] = source.variables[var][:]
+
+#global attributes
+print("Now copying global attributes")
+dest.setncatts(source.__dict__)
+
+print("Now updating history")
+text = "strip_metadata_padding.py {}".format(source.filepath())
+dest.history = "{}: {}\n".format(time.ctime(time.time()), text) + (dest.history if "history" in dest.ncattrs() else "")
+
+source.close()
+dest.close()


### PR DESCRIPTION
As a quick workaround for [this issue](https://github.com/pacificclimate/modelmeta/issues/65), 72 climdex climatology files needed for a time-sensitive project were stripped of their header padding in order to make indexing into `ce_meta` possible.

This action archive contains the relevant script and a list of the files it was used on.