### PR TITLE
Add YAML that updates PCIC metadata v55->v65

### DIFF
--- a/actions/update-downscaled-metadata/DESCRIPTION.md
+++ b/actions/update-downscaled-metadata/DESCRIPTION.md
@@ -1,0 +1,20 @@
+# Update PCIC Standard Metadata
+
+## Purpose and Procedure
+This .yaml file can be used with the modelmeta `update_metadata` script to update netCDF metadata in a GCM downscaled dataset that is compliant with version 55 of the PCIC Metadata Standard (September 2017) to version 65 of the PCIC Metadata Standard (Octover 2017 to present) for dowwnscaled GCM output.
+
+It renames required global attributes, but does not change any values.
+* required attributes named `driving_x` are renamed `GCM__x`
+* required attributes named `downscaling_x` are renamed `x`
+* required attributes named `target_x` are renamed `target__x`
+
+To use this file, copy it into the modelmeta directory, then
+
+```
+python scripts/update_metadata -u pcic_downscaled_metadata_55to65.yaml file_to_upgrade.nc
+```
+
+## Datasets updated with this file:
+* Annual degree-day data for Climate Explorer
+* 20 year return period data for Climate Explorer
+* BCCAQ v2 data for the PDP

--- a/actions/update-downscaled-metadata/pcic_downscaled_metadata_55to65.yaml
+++ b/actions/update-downscaled-metadata/pcic_downscaled_metadata_55to65.yaml
@@ -1,0 +1,30 @@
+# This update template renames global metadata attributes to
+# update a netCDF from the penultimate PCIC metadata standard
+# to the current (as of September 2018) PCIC metadata standard.
+# No values are changed, just attribute names.
+#
+# 1. 'driving_x' is renamed 'GCM__x' (8 attributes)
+# 2. 'downscaling_x' is renamed 'x' (3 attributes)
+# 3. 'target_x' is renamed 'target__x' (7 attributes)
+
+global:
+  GCM__experiment: <-driving_experiment
+  GCM__experiment_id: <-driving_experiment_id
+  GCM__institution: <-driving_institution
+  GCM__institute_id: <-driving_institute_id
+  GCM__model_id: <-driving_model_id
+  GCM__realization: <-driving_realization
+  GCM__initialization_method: <-driving_initialization_method
+  GCM__physics_version: <-driving_physics_version
+
+  method: <-downscaling_method
+  method_id: <-downscaling_method_id
+  package_id: <-downscaling_package_id
+
+  target__institution: <-target_institution
+  target__institute_id: <-target_institute_id
+  target__dataset: <-target_dataset
+  target__dataset_id: <-target_dataset_id
+  target__references: <-target_references
+  target__version: <-target_version
+  target__contact: <-target_contact


### PR DESCRIPTION
This .yaml file can be used by the update_metadata script to upgrade metdata from PCIC Metadata Standard Version 55 to PCIC Metadata Standard Version 65. 

It changes some global attribute names. No attribute values are affected.