### PR TITLE
Add metadata for degree day datasets

### DIFF
--- a/actions/metadata-for-degree-days/DESCRIPTION.md
+++ b/actions/metadata-for-degree-days/DESCRIPTION.md
@@ -1,6 +1,8 @@
 # Metadata for Degree Day Files
 
-These files are inputs to the update_metadata script and provide metadata that is missing from degree day datasets. Both times I have worked on this data, it's been in pretty good shape and only a few files needed any work beyond this.
+These files are inputs to the update_metadata script and provide metadata that is missing from degree day datasets. Both times I have worked on this data, it's been in pretty good shape.
+
+First, the v55->v65 update yaml should be run on files if they're the old metadata version.
 
 global.yaml can be run on all files to provide missing metadata, something like:
 
@@ -12,9 +14,15 @@ for file in /path/to/files/*.nc ; do python scripts/update_metadata -u global.ya
 The four variable files add human friendly variable descriptions taken from a variable metadata spreadsheet Trevor gave me. There's no harm in running these updates on the wrong variables; they just spit error messages. Something like:
 
 ```
-for file in /path/to/files/cdd*.nc ; do python scripts update_metadata -u cdd.yaml $file ; done
-for file in /path/to/files/fdd*.nc ; do python scripts update_metadata -u fdd.yaml $file ; done
-for file in /path/to/files/gdd*.nc ; do	python scripts update_metadata -u gdd.yaml $file ; done
-for file in /path/to/files/hdd*.nc ; do	python scripts update_metadata -u hdd.yaml $file ; done
+for file in /path/to/files/cdd*.nc ; do update_metadata -u cdd.yaml $file ; done
+for file in /path/to/files/fdd*.nc ; do update_metadata -u fdd.yaml $file ; done
+for file in /path/to/files/gdd*.nc ; do	update_metadata -u gdd.yaml $file ; done
+for file in /path/to/files/hdd*.nc ; do	update_metadata -u hdd.yaml $file ; done
 
+```
+
+The GFDL-ESM2G model's files were missing run (r1i1p1) and experiment (rcp85) information. The missing data can be added with r1i1p1.yaml and rcp85.yaml:
+```
+for file in /path/to/files/*r1i1p1*.nc ; do update_metadata -u r1i1p1.yaml $file ; done
+for file in /path/to/files/*rcp85*.nc ; do update_metadata -u rcp85.yaml $file ; done
 ```

--- a/actions/metadata-for-degree-days/DESCRIPTION.md
+++ b/actions/metadata-for-degree-days/DESCRIPTION.md
@@ -1,0 +1,20 @@
+# Metadata for Degree Day Files
+
+These files are inputs to the update_metadata script and provide metadata that is missing from degree day datasets. Both times I have worked on this data, it's been in pretty good shape and only a few files needed any work beyond this.
+
+global.yaml can be run on all files to provide missing metadata, something like:
+
+```
+for file in /path/to/files/*.nc ; do python scripts/update_metadata -u global.yaml $file ; done
+```
+(Note that global.yaml provides a couple options that may vary across your data collection: method, method_id, and package_id. These are currently set for BCCAQv2; change or remove them if your dataset was generated some other way.)
+
+The four variable files add human friendly variable descriptions taken from a variable metadata spreadsheet Travis gave me. There's no harm in running these updates on the wrong variables; they just spit error messages. Something like:
+
+```
+for file in /path/to/files/cdd*.nc ; do python scripts update_metadata -u cdd.yaml $file ; done
+for file in /path/to/files/fdd*.nc ; do python scripts update_metadata -u fdd.yaml $file ; done
+for file in /path/to/files/gdd*.nc ; do	python scripts update_metadata -u gdd.yaml $file ; done
+for file in /path/to/files/hdd*.nc ; do	python scripts update_metadata -u hdd.yaml $file ; done
+
+```

--- a/actions/metadata-for-degree-days/DESCRIPTION.md
+++ b/actions/metadata-for-degree-days/DESCRIPTION.md
@@ -9,7 +9,7 @@ for file in /path/to/files/*.nc ; do python scripts/update_metadata -u global.ya
 ```
 (Note that global.yaml provides a couple options that may vary across your data collection: method, method_id, and package_id. These are currently set for BCCAQv2; change or remove them if your dataset was generated some other way.)
 
-The four variable files add human friendly variable descriptions taken from a variable metadata spreadsheet Travis gave me. There's no harm in running these updates on the wrong variables; they just spit error messages. Something like:
+The four variable files add human friendly variable descriptions taken from a variable metadata spreadsheet Trevor gave me. There's no harm in running these updates on the wrong variables; they just spit error messages. Something like:
 
 ```
 for file in /path/to/files/cdd*.nc ; do python scripts update_metadata -u cdd.yaml $file ; done

--- a/actions/metadata-for-degree-days/cdd.yaml
+++ b/actions/metadata-for-degree-days/cdd.yaml
@@ -1,4 +1,4 @@
 cdd:
   standard_name: cooling_degree_days
   long_name: "Cooling Degree Days (Threshold: 18C)"
-  cell_methods: "time:sum"
+  cell_methods: "time: sum within years"

--- a/actions/metadata-for-degree-days/cdd.yaml
+++ b/actions/metadata-for-degree-days/cdd.yaml
@@ -1,0 +1,4 @@
+cdd:
+  standard_name: cooling_degree_days
+  long_name: "Cooling Degree Days (Threshold: 18C)"
+  cell_methods: "time:sum"

--- a/actions/metadata-for-degree-days/fdd.yaml
+++ b/actions/metadata-for-degree-days/fdd.yaml
@@ -1,0 +1,4 @@
+fdd:
+  standard_name: freezing_degree_days
+  long_name: "Freezing Degree Days (Threshold: 0C)"
+  cell_methods: "time:sum"

--- a/actions/metadata-for-degree-days/fdd.yaml
+++ b/actions/metadata-for-degree-days/fdd.yaml
@@ -1,4 +1,4 @@
 fdd:
   standard_name: freezing_degree_days
   long_name: "Freezing Degree Days (Threshold: 0C)"
-  cell_methods: "time:sum"
+  cell_methods: "time: sum within years"

--- a/actions/metadata-for-degree-days/gdd.yaml
+++ b/actions/metadata-for-degree-days/gdd.yaml
@@ -1,0 +1,5 @@
+gdd:
+  standard_name: growing_degree_days
+  long_name: "Growing Degree Days (Threshold: 5C)"
+  cell_methods: "time:sum"
+

--- a/actions/metadata-for-degree-days/gdd.yaml
+++ b/actions/metadata-for-degree-days/gdd.yaml
@@ -1,5 +1,5 @@
 gdd:
   standard_name: growing_degree_days
   long_name: "Growing Degree Days (Threshold: 5C)"
-  cell_methods: "time:sum"
+  cell_methods: "time: sum within years"
 

--- a/actions/metadata-for-degree-days/global.yaml
+++ b/actions/metadata-for-degree-days/global.yaml
@@ -1,0 +1,14 @@
+# fills in metadata attributes missing from degree-day files.
+
+global:
+  version: "1" 
+  contact: Pacific Climate Impacts Consortium
+  target__history: <-target_history
+  target__dataset_id: <-target_id
+  table_id: Table day (10 Jun 2010)
+  project_id: CMIP5
+  product: downscaled output
+  domain: Canada
+  method: Quantile Delta Mapping
+  package_id: github.com/pacificclimate/ClimDown
+  method_id: BCCAQv2

--- a/actions/metadata-for-degree-days/hdd.yaml
+++ b/actions/metadata-for-degree-days/hdd.yaml
@@ -1,4 +1,4 @@
 hdd:
   standard_name: heating_degree_days
   long_name: "Heating Degree Days (Threshold: 18C)"
-  cell_methods: "time:sum"
+  cell_methods: "time: sum within years"

--- a/actions/metadata-for-degree-days/hdd.yaml
+++ b/actions/metadata-for-degree-days/hdd.yaml
@@ -1,0 +1,4 @@
+hdd:
+  standard_name: heating_degree_days
+  long_name: "Heating Degree Days (Threshold: 18C)"
+  cell_methods: "time:sum"

--- a/actions/metadata-for-degree-days/r1i1p1.yaml
+++ b/actions/metadata-for-degree-days/r1i1p1.yaml
@@ -1,0 +1,4 @@
+global:
+  GCM__realization: 1
+  GCM__initialization_method: 1
+  GCM__physics_version: 1

--- a/actions/metadata-for-degree-days/rcp85.yaml
+++ b/actions/metadata-for-degree-days/rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+  GCM__experiment_id: "historical,rcp85"


### PR DESCRIPTION
Adds 5 metadata YAML files that were used with the `update_metadata` script to add missing metadata to degree day files. There's one global one that adds attributes shared by all files, as well as a file for each of the four degree day variables that adds human-friendly descriptions.

There were a couple files that required weirder interventions, but overall this is a data set with very good metadata.