### PR TITLE
Update metadata in climate-explorer-data-prep test files

### DIFF
--- a/actions/update-data-prep-tests/DESCRIPTION.md
+++ b/actions/update-data-prep-tests/DESCRIPTION.md
@@ -1,0 +1,24 @@
+# Update Climate Explorer Data Prep Test File Metadata
+
+## Purpose
+The metadata for `tiny_hydromodel_gcm_climos.nc`, `tiny_hydromodel_gcm.nc`, `tiny_downscaled_tasmax.nc`, `tiny_downscaled_tasmax_climos.nc`, `tiny_downscaled_pr.nc` and `tiny_downscaled_pr_packed.nc` in the [climate-explorer-data-prep](https://github.com/pacificclimate/climate-explorer-data-prep) test files were out of date.  This was causing a series of failures during testing and needed to be updated.
+
+## Commands
+
+Using the [`update_metadata`](https://github.com/pacificclimate/climate-explorer-data-prep/blob/master/dp/update_metadata.py) script.
+
+### 1. Update the hydromodel test files
+```
+(venv)$ for file in path/to/climate-explorer-data-prep/tests/data/tiny_hydromodel*.nc ; do python scripts/update_metadata -u ../update_hydromodel.yaml $file; done
+```
+
+### 2. Update downscaled test files
+
+```
+(venv)$ for file in path/to/climate-explorer-data-prep/tests/data/tiny_downscaled*.nc ; do python scripts/update_metadata -u ../update_downscaled.yaml $file; done
+```
+
+### 3. Add missing variable to pr test files
+```
+(venv)$ for file in path/to/climate-explorer-data-prep/tests/data/tiny_downscaled_pr*.nc ; do python scripts/update_metadata -u ../update_pr.yaml $file; done
+```

--- a/actions/update-data-prep-tests/update_downscaled.yaml
+++ b/actions/update-data-prep-tests/update_downscaled.yaml
@@ -1,0 +1,21 @@
+global:
+  GCM__experiment: <-driving_experiment
+  GCM__experiment_id: <-driving_experiment_id
+  GCM__institution: <-driving_institution
+  GCM__institute_id: <-driving_institute_id
+  GCM__model_id: <-driving_model_id
+  GCM__realization: <-driving_realization
+  GCM__initialization_method: <-driving_initialization_method
+  GCM__physics_version: <-driving_physics_version
+
+  method: <-downscaling_method
+  method_id: <-downscaling_method_id
+  package_id: <-downscaling_package_id
+
+  target__institution: <-target_institution
+  target__institute_id: <-target_institute_id
+  target__dataset: <-target_dataset
+  target__dataset_id: <-target_dataset_id
+  target__references: <-target_references
+  target__version: <-target_version
+  target__contact: <-target_contact

--- a/actions/update-data-prep-tests/update_hydromodel.yaml
+++ b/actions/update-data-prep-tests/update_hydromodel.yaml
@@ -1,0 +1,23 @@
+global:
+        downscaling__method: <-forcing_downscaling_method
+        downscaling__method_id: <-forcing_downscaling_method_id
+        downscaling__package_id: <-forcing_downscaling_package_id
+
+        downscaling__GCM__experiment: <-forcing_driving_experiment
+        downscaling__GCM__experiment_id: <-forcing_driving_experiment_id
+        downscaling__GCM__initialization_method: <-forcing_driving_initialization_method
+        downscaling__GCM__institute_id: <-forcing_driving_institute_id
+        downscaling__GCM__institution: <-forcing_driving_institution
+        downscaling__GCM__model_id: <-forcing_driving_model_id
+        downscaling__GCM__physics_version: <-forcing_driving_physics_version
+        downscaling__GCM__realization: <-forcing_driving_realization
+
+        model_cal__contact: <-forcing_target_contact
+        model_cal__dataset: <-forcing_target_dataset
+        model_cal__dataset_id: <-forcing_target_dataset_id
+        model_cal__institute_id: <-forcing_target_institute_id
+        model_cal__institution: <-forcing_target_institution
+        model_cal__references: <-forcing_target_references
+        model_cal__version: <-forcing_target_version
+
+        method_id: <-hydromodel_method_id

--- a/actions/update-data-prep-tests/update_pr.yaml
+++ b/actions/update-data-prep-tests/update_pr.yaml
@@ -1,0 +1,2 @@
+global:
+        project_id: 'CMIP5'


### PR DESCRIPTION
Adds 3 metadata YAML files that were used with the update_metadata script to add missing metadata to climate-explorer-data-prep test files. There are plenty of globals that have been renamed to fit the metadata standard, and a single new global was added.  In total 6 of the test files were changed.