### PR TITLE
Document frost day metadata additions

### DIFF
--- a/actions/frost-days/DESCRIPTION.md
+++ b/actions/frost-days/DESCRIPTION.md
@@ -1,8 +1,6 @@
 # Add metadata to fdETCCDI datafiles
 
 ## Purpose
-The ANUSPLIN dataset was added for the [p2a](https://github.com/pacificclimate/p2a-rule-engine) rule engine.  It will replace `CRU_TS_21` as the new historical baseline.  The following commands were run to produce the climatologies.
-
 The [p2a](https://github.com/pacificclimate/p2a-rule-engine) rule engine required monthy fdETCCDI data in order to produce `number of frost free days`.  The following commands were run in order to add metadata to the files.
 
 ## Commands

--- a/actions/frost-days/DESCRIPTION.md
+++ b/actions/frost-days/DESCRIPTION.md
@@ -1,0 +1,77 @@
+# Add metadata to fdETCCDI datafiles
+
+## Purpose
+The ANUSPLIN dataset was added for the [p2a](https://github.com/pacificclimate/p2a-rule-engine) rule engine.  It will replace `CRU_TS_21` as the new historical baseline.  The following commands were run to produce the climatologies.
+
+The [p2a](https://github.com/pacificclimate/p2a-rule-engine) rule engine required monthy fdETCCDI data in order to produce `number of frost free days`.  The following commands were run in order to add metadata to the files.
+
+## Commands
+
+### 1. Add metadata common to all files
+
+Using the `update_metadata` script from [climate-explorer-data-prep](https://github.com/pacificclimate/climate-explorer-data-prep).
+
+```
+(venv)$ for file in fd/*.nc ; do python scripts/update_metadata -u all_shared.yaml $file ; done
+```
+
+### 2. Add metadata common to all files with the same emission scenario
+
+```
+(venv)$ for file in fd/*rcp45*.nc ; do python scripts/update_metadata -u fd_rcp45.yaml $file ; done
+(venv)$ for file in fd/*rcp85*.nc ; do python scripts/update_metadata -u fd_rcp85.yaml $file ; done
+```
+
+### 3. Add metadata common to files with the same ensemble members
+
+```
+(venv)$ for file in fd/*r1i1p1*.nc ; do python scripts/update_metadata -u fd_r1i1p1.yaml $file ; done
+(venv)$ for file in fd/*r2i1p1*.nc ; do python scripts/update_metadata -u fd_r2i1p1.yaml $file ; done
+(venv)$ for file in fd/*r3i1p1*.nc ; do python scripts/update_metadata -u fd_r3i1p1.yaml $file ; done
+```
+
+### 4. Add metadata common to files with model
+
+```
+(venv)$ for file in fd/*ACCESS1-0*.nc ; do python scripts/update_metadata -u fd_ACCESS1-0.yaml $file ; done
+(venv)$ for file in fd/*CanESM2*.nc ; do python scripts/update_metadata -u fd_CanESM2.yaml $file ; done
+(venv)$ for file in fd/*CCSM4*.nc ; do python scripts/update_metadata -u fd_CCSM4.yaml $file ; done
+(venv)$ for file in fd/*CNRM-CM5*.nc ; do python scripts/update_metadata -u fd_CNRM-CM5.yaml $file ; done
+(venv)$ for file in fd/*CSIRO-Mk3-6-0*.nc ; do python scripts/update_metadata -u fd_CSIRO-Mk3-6-0.yaml $file ; done
+(venv)$ for file in fd/*GFDL-ESM2G*.nc ; do python scripts/update_metadata -u fd_GFDL-ESM2G.yaml $file ; done
+(venv)$ for file in fd/*HadGEM2-CC*.nc ; do python scripts/update_metadata -u fd_HadGEM2-CC.yaml $file ; done
+(venv)$ for file in fd/*HadGEM2-ES*.nc ; do python scripts/update_metadata -u fd_HadGEM2-ES.yaml $file ; done
+(venv)$ for file in fd/*inmcm4*.nc ; do python scripts/update_metadata -u fd_inmcm4*.yaml $file ; done
+(venv)$ for file in fd/*MIROC5*.nc ; do python scripts/update_metadata -u fd_MIROC5.yaml $file ; done
+(venv)$ for file in fd/*MPI-ESM-LR*.nc ; do python scripts/update_metadata -u fd_MPI-ESM-LR.yaml $file ; done
+(venv)$ for file in fd/*MRI-CGCM3*.nc ; do python scripts/update_metadata -u fd_MRI-CGCM3.yaml $file ; done
+```
+
+### 5. Add metadata specific to each file
+
+```
+(venv)$ python scripts/update_metadata -u fd_ACCESS1-0_rcp45.yaml fdETCCDI_mon_ACCESS1-0_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_ACCESS1-0_rcp85.yaml fdETCCDI_mon_ACCESS1-0_rcp85_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_CanESM2_rcp45.yaml fdETCCDI_mon_CanESM2_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_CanESM2_rcp8.yaml fdETCCDI_mon_CanESM2_rcp85_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_CCSM4_rcp45.yaml fdETCCDI_mon_CCSM4_rcp45_r2i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_CCSM4_rcp85.yaml fdETCCDI_mon_CCSM4_rcp85_r2i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_CNRM-CM5_rcp45.yaml fdETCCDI_mon_CNRM-CM5_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_CNRM-CM5_rcp85.yaml fdETCCDI_mon_CNRM-CM5_rcp85_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_CSIRO-Mk3-6-0.yaml fdETCCDI_mon_CSIRO-Mk3-6-0_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_CSIRO-Mk3-6-0_rcp85.yaml fdETCCDI_mon_CSIRO-Mk3-6-0_rcp85_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_GFDL-ESM2G_rcp45.yaml fdETCCDI_mon_GFDL-ESM2G_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_GFDL-ESM2G_rcp85.yaml fdETCCDI_mon_GFDL-ESM2G_rcp85_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_HadGEM2-CC_rcp45.yaml fdETCCDI_mon_HadGEM2-CC_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_HadGEM2-CC_rcp85.yaml fdETCCDI_mon_HadGEM2-CC_rcp85_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_HadGEM2-ES_rcp45.yaml fdETCCDI_mon_HadGEM2-ES_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_HadGEM2-ES_rcp85.yaml fdETCCDI_mon_HadGEM2-ES_rcp85_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_inmcm4_rcp45.yaml fdETCCDI_mon_inmcm4_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_inmcm4_rcp85.yaml fdETCCDI_mon_inmcm4_rcp85_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_MIROC5_rcp45.yaml fdETCCDI_mon_MIROC5_rcp45_r3i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_MIROC5_rcp85.yaml fdETCCDI_mon_MIROC5_rcp85_r3i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_MPI-ESM-LR_rcp45.yaml fdETCCDI_mon_MPI-ESM-LR_rcp45_r3i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_MPI-ESM-LR_rcp85.yaml fdETCCDI_mon_MPI-ESM-LR_rcp85_r3i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_MRI-CGCM3_rcp45.yaml fdETCCDI_mon_MRI-CGCM3_rcp45_r1i1p1_1951-2100.nc
+(venv)$ python scripts/update_metadata -u fd_MRI-CGCM3_rcp85.yaml fdETCCDI_mon_MRI-CGCM3_rcp85_r1i1p1_1951-2100.nc
+```

--- a/actions/frost-days/frost-day-metadata/all_shared.yaml
+++ b/actions/frost-days/frost-day-metadata/all_shared.yaml
@@ -1,0 +1,27 @@
+global:
+        - contact: Pacfic Climate Impacts Consortium
+        - Conventions: CF-1.4
+        - creation_date: '2019-03-05T10:58:00Z'
+        - frequency: mon
+        - institute_id: PCIC
+        - institution: Pacific Climate Impacts Consortium (PCIC), Victoria, BC, www.pacificclimate.org
+        - modeling_realm: atmos
+        - product: downscaled output
+        - project_id: CMIP5
+        - table_id: Table day (10 Jun 2010)
+        - title: ETCCDI indices computed on Bias Correction/Constructed Analogue Quantile Mapping (BCCAQ) downscaling model output for Canada
+        
+        - method: Bias Correction/Constructed Analogue Quantile Mapping (BCCAQ)
+        - method_id: BCCAQ
+        - package_id: github.com/pacificclimate/ClimDown 
+        
+        - target__contact: Pia Papadopol (pia.papadopol@nrcan-rncan.gc.ca)
+        - target__dataset: ANUSPLIN interpolated Canada daily 300 arc second climate grids
+        - target__dataset_id: ANUSPLIN300
+        - target__institute_id: CFS-NRCan
+        - target__institution: Canadian Forest Service, Natural Resources Canada
+        - target__references: 'McKenney, D.W., Hutchinson, M.F., Papadopol, P., Lawrence, K., Pedlar, J.,\nCampbell, K., Milewska, E., Hopkinson, R., Price, D., and Owen, T.,\n2011. Customized spatial climate models for North America.\nBulletin of the American Meteorological Society, 92(12): 1611-1622.\n\nHopkinson, R.F., McKenney, D.W., Milewska, E.J., Hutchinson, M.F.,\nPapadopol, P., Vincent, L.A., 2011. Impact of aligning climatological day\non gridding daily maximum-minimum temperature and precipitation over Canada.\nJournal of Applied Meteorology and Climatology 50: 1654-1665.'
+        - target__version: canada_daily_standard_grids
+
+fdETCCDI:
+        cell_methods: 'time: sum within years'

--- a/actions/frost-days/frost-day-metadata/fd_ACCESS1-0.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_ACCESS1-0.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: CSIRO-BOM
+        GCM__institution: Commonwealth Scientific and Industrial Research Organization (CSIRO) and Bureau of Meteorology (BOM), Australia
+        GCM__model_id: ACCESS1-0

--- a/actions/frost-days/frost-day-metadata/fd_ACCESS1-0_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_ACCESS1-0_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: ACCESS1-0, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_ACCESS1-0_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_ACCESS1-0_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: ACCESS1-0, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_CCSM4.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CCSM4.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: NCAR
+        GCM__institution: National Center for Atmospheric Research
+        GCM__model_id: CCSM4

--- a/actions/frost-days/frost-day-metadata/fd_CCSM4_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CCSM4_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: CCSM4, historical+rcp45, r2i1p1

--- a/actions/frost-days/frost-day-metadata/fd_CCSM4_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CCSM4_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: CCSM4, historical+rcp85, r2i1p1

--- a/actions/frost-days/frost-day-metadata/fd_CNRM-CM5.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CNRM-CM5.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: CNRM-CM5
+        GCM__institution: Centre National de Recherches Meteorologiques / Centre Europeen de Recherche et Formation Avancee en Calcul Scientifique
+        GCM__model_id: CNRM-CM5

--- a/actions/frost-days/frost-day-metadata/fd_CNRM-CM5_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CNRM-CM5_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: CNRM-CM5, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_CNRM-CM5_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CNRM-CM5_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: CNRM-CM5, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_CSIRO-Mk3-6-0.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CSIRO-Mk3-6-0.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: CSIRO-QCCCE
+        GCM__institution: Commonwealth Scientific and Industrial Research Organization in collaboration with Queensland Climate Change Centre of Excellence
+        GCM__model_id: CSIRO-Mk3-6-0

--- a/actions/frost-days/frost-day-metadata/fd_CSIRO-Mk3-6-0_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CSIRO-Mk3-6-0_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: CSIRO-Mk3-6-0, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_CSIRO-Mk3-6-0_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CSIRO-Mk3-6-0_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: CSIRO-Mk3-6-0, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_CanESM2.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CanESM2.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: CCCma
+        GCM__institution: Canadian Centre for Climate Modelling and Analysis
+        GCM__model_id: CanESM2

--- a/actions/frost-days/frost-day-metadata/fd_CanESM2_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CanESM2_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: CanESM2, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_CanESM2_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_CanESM2_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: CanESM2, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_GFDL-ESM2G.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_GFDL-ESM2G.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: NOAA GFDL
+        GCM__institution: Canadian Forest Service, Natural Resources Canada
+        GCM__model_id: GFDL-ESM2G

--- a/actions/frost-days/frost-day-metadata/fd_GFDL-ESM2G_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_GFDL-ESM2G_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: GFDL-ESM2G, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_GFDL-ESM2G_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_GFDL-ESM2G_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: GFDL-ESM2G, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_HadGEM2-CC.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_HadGEM2-CC.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: MOHC
+        GCM__institution: Met Office Hadley Centre
+        GCM__model_id: HadGEM2-CC

--- a/actions/frost-days/frost-day-metadata/fd_HadGEM2-CC_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_HadGEM2-CC_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: HadGEM2-CC, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_HadGEM2-CC_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_HadGEM2-CC_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: HadGEM2-CC, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_HadGEM2-ES.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_HadGEM2-ES.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: MOHC
+        GCM__institution: Met Office Hadley Centre
+        GCM__model_id: HadGEM2-ES

--- a/actions/frost-days/frost-day-metadata/fd_HadGEM2-ES_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_HadGEM2-ES_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: HadGEM2-ES, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_HadGEM2-ES_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_HadGEM2-ES_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: HadGEM2-ES, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_MIROC5.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MIROC5.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: MIROC
+        GCM__institution: Atmosphere and Ocean Research Institute (The University of Tokyo), National Institute for Environmental Studies, and Japan Agency for Marine-Earth Science and Technology
+        GCM__model_id: MIROC5

--- a/actions/frost-days/frost-day-metadata/fd_MIROC5_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MIROC5_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: MIROC5, historical+rcp45, r3i1p1

--- a/actions/frost-days/frost-day-metadata/fd_MIROC5_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MIROC5_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: MIROC5, historical+rcp85, r3i1p1

--- a/actions/frost-days/frost-day-metadata/fd_MPI-ESM-LR.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MPI-ESM-LR.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: MPI-M
+        GCM__institution: Max-Planck-Institut fur Meteorologie (Max Planck Institute for Meteorology)
+        GCM__model_id: MPI-ESM-LR

--- a/actions/frost-days/frost-day-metadata/fd_MPI-ESM-LR_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MPI-ESM-LR_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: MPI_ESM_LR, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_MPI-ESM-LR_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MPI-ESM-LR_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: MPI-ESM-LR, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_MRI-CGCM3.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MRI-CGCM3.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: MRI
+        GCM__institution: Meteorological Research Institute
+        GCM__model_id: MRI-CGCM3

--- a/actions/frost-days/frost-day-metadata/fd_MRI-CGCM3_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MRI-CGCM3_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: MRI-CGCM3, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_MRI-CGCM3_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_MRI-CGCM3_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: MRI-CGCM3, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_inmcm4.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_inmcm4.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__institute_id: INM
+        GCM__institution: Institute for Numerical Mathematics
+        GCM__model_id: inmcm4

--- a/actions/frost-days/frost-day-metadata/fd_inmcm4_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_inmcm4_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: inmcm4, historical+rcp45, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_inmcm4_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_inmcm4_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment: inmcm4, historical+rcp85, r1i1p1

--- a/actions/frost-days/frost-day-metadata/fd_r1i1p1.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_r1i1p1.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__realization: 1
+        GCM__initialization_method: 1
+        GCM__physics_version: 1

--- a/actions/frost-days/frost-day-metadata/fd_r2i1p1.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_r2i1p1.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__realization: 2
+        GCM__initialization_method: 1
+        GCM__physics_version: 1

--- a/actions/frost-days/frost-day-metadata/fd_r3i1p1.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_r3i1p1.yaml
@@ -1,0 +1,4 @@
+global:
+        GCM__realization: 3
+        GCM__initialization_method: 1
+        GCM__physics_version: 1

--- a/actions/frost-days/frost-day-metadata/fd_rcp45.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_rcp45.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment_id: historical, rcp45

--- a/actions/frost-days/frost-day-metadata/fd_rcp85.yaml
+++ b/actions/frost-days/frost-day-metadata/fd_rcp85.yaml
@@ -1,0 +1,2 @@
+global:
+        GCM__experiment_id: historical, rcp85


### PR DESCRIPTION
Adds **42** yaml files containing all required attributes as listed in the **PCIC metadata standards**.  The files had 0 metadata to start so everything that was required was added and all the commands are listed in the description.