### PR TITLE
Add a warning about non-monotonic time values

### DIFF
--- a/actions/normalize-pdp-time/DESCRIPTION.md
+++ b/actions/normalize-pdp-time/DESCRIPTION.md
@@ -58,9 +58,11 @@ data:
 }
 ```
 
-WARNING 1: this script has not been tested outside the dataset it was written for use with. Be very careful about applying it to new datasets.
+**WARNING 1**: this script has not been tested outside the dataset it was written for use with. Be very careful about applying it to new datasets.
 
 For example, as checks on data consistency, it assumes that the dataset starts January first and that the dataset has a CMOR-style filename containing extractable dates. These assumptions are *not* reliable across all PCIC datasets or all netCDF files.
+
+**WARNING 2**: This script does not check that all values in the time variable either monotonically increasing and equally spaced; a file that violated those constraints recently cause us some trouble.
 
 
 ## Procedure


### PR DESCRIPTION
We recently discovered that one of the BCCAQ2 files time value had an erroneous 0 value in the middle of the time array. This is the sort of thing the remove time offset script should probably check for, but it doesn't, so add a warning to that effect,
