### PR TITLE
Formatting for time-invariant watershed data

### DIFF
--- a/actions/elevation.yaml
+++ b/actions/elevation.yaml
@@ -1,0 +1,15 @@
+global:
+  institude_id:
+  institute_id: PCIC
+  product: gridded observations
+  frequency: fx
+  creation_date: 2018-01-08-T11:05:31Z
+  project_id: other
+  domain: nwna
+  experiment_id: historical
+  modeling_realm: land
+  model_id: base
+  run: run1
+
+elev:
+  cell_methods: "area: mean"

--- a/actions/format-watershed-data/DESCRIPTION.md
+++ b/actions/format-watershed-data/DESCRIPTION.md
@@ -1,0 +1,25 @@
+# Metadata for watershed data files
+
+These files are inputs to the `update_metadata` script and provide metadata needed to format RVIC input files for use with the PCEX system, used with the watershed API endpoint to provide data about the watershed that drains to a specific point.
+
+Area data, which provides the area in meters of each grid square, is extracted from a domain file:
+
+```
+cdo selvar,area,lon,lat domain.rvic.peace.20161018.nc area.nc
+update_metadata -u area.yaml area.nc
+```
+
+Elevation is extracted from a soils file:
+```
+cdo selvar,elev,lon,lat soils_gen2_20170606.nc elevation.nc
+update_metadata -u elevation.yaml elevation.nc
+```
+
+Flow direction is extracted from a routing file (and then converted to lowercase):
+```
+cdo selvar,Flow_Direction,lat,lon bc.rvic.peace.20171019.nc flow-direction_peace.nc.tmp
+cdo chname,Flow_Direction,flow_direction flow-direction_peace.nc.tmp flow-direction_peace.nc
+update_metadata -y flow_direction.yaml flow-direction_peace.nc 
+```
+
+At which point the files should be ready for indexing.

--- a/actions/format-watershed-data/area.yaml
+++ b/actions/format-watershed-data/area.yaml
@@ -1,0 +1,19 @@
+global:
+  institute_id: PCIC
+  institution: Pacific Climate Impacts Consortium
+  contact: Markus Schnorbus, mschnorb@uvic.ca
+  product: gridded observations
+  frequency: fx
+  creation_date: 2016-10-18-T13:55:23Z
+  project_id: other
+  domain: nwna
+  experiment_id: historical
+  modeling_realm: land
+  model_id: RVIC
+  model: RVIC streamflow routing model
+  model_version: 1.0.0
+  run: na
+  table_id: na
+
+area:
+  cell_methods: "area: sum"

--- a/actions/format-watershed-data/elevation.yaml
+++ b/actions/format-watershed-data/elevation.yaml
@@ -8,8 +8,8 @@ global:
   domain: nwna
   experiment_id: historical
   modeling_realm: land
-  model_id: base
-  run: run1
+  model_id: GMTED2010
+  run: na
 
 elev:
   cell_methods: "area: mean"

--- a/actions/format-watershed-data/flow_direction.yaml
+++ b/actions/format-watershed-data/flow_direction.yaml
@@ -1,0 +1,21 @@
+global:
+  institution: Pacific Climate Impacts Consortium
+  title: RVIC flow direction data
+  creation_date: 2016-10-18-T15:16:55
+  contact: Markus Schnorbus, mschnorb@uvic.ca
+  domain: peace
+  modeling_realm: land
+  product: gridded observations
+  frequency: fx
+  project_id: other
+  table_id: na
+  institute_id: PCIC
+  experiment_id: historical
+  run: na
+  model: RVIC streamflow routing model
+  model_id: RVIC
+  model_version: 1.0.0
+
+flow_direction:
+    cell_methods: "area: point"
+    units: "1"


### PR DESCRIPTION
This isn't ready to merge yet, but I'd like @rod-glover to check over the metadata at this point. This YAML file is run by update_metadata to adjust the metadata for a dataset that contains elevation data for the pacific northwest. Some of the attribute values were derived from the PCIC standards, but some were derived from more speculative documents, or previous datasets.

It is treated as gridded observations with no time axis.

After running the update script, the metadata for the file is the following:
```
netcdf elevation {
dimensions:
	lon = 1088 ;
	lat = 512 ;
variables:
	double lon(lon) ;
		lon:standard_name = "longitude" ;
		lon:long_name = "longitude" ;
		lon:units = "degrees_east" ;
		lon:axis = "X" ;
	double lat(lat) ;
		lat:standard_name = "latitude" ;
		lat:long_name = "latitude" ;
		lat:units = "degrees_north" ;
		lat:axis = "Y" ;
	float elev(lat, lon) ;
		elev:long_name = "Average elevation of grid cell" ;
		elev:units = "m" ;
		elev:_FillValue = NaNf ;
		elev:missing_value = NaNf ;
		elev:cell_methods = "area: mean" ;

// global attributes:
		:CDI = "Climate Data Interface version ?? (http://mpimet.mpg.de/cdi)" ;
		:Conventions = "CF 1.7" ;
		:history =  [elided for length]
		:institution = "Pacific Climate Impacts Consortium" ;
		:title = "VICGL soil parameter file - uncalibrated" ;
		:creation_date = "2018-01-08-T11:05:31Z" ;
		:contact = [Markus' contact info removed]
		:domain = "nwna" ;
		:modeling_realm = "land" ;
		:product = "gridded observations" ;
		:frequency = "fx" ;
		:project_id = "other" ;
		:table_id = "na" ;
		:forcing_type = "na" ;
		:forcing_domain = "na" ;
		:configuration_id = "VICGL_1_0.0 and VICGL_1_0.1" ;
		:method = "Variable Infiltration Capacity Model - Glacier" ;
		:method_id = "VIC-GL" ;
		:version = "VICGL 1.0" ;
		:resolution = "0.0625 decimal-degrees" ;
		:type = "gridded parameters" ;
		:NCO = "\"4.6.0\"" ;
		:CDO = "Climate Data Operators version 1.9.3 (http://mpimet.mpg.de/cdo)" ;
		:institute_id = "PCIC" ;
		:experiment_id = "historical" ;
		:model_id = "base" ;
		:run = "run1" ;
}
```