### PR TITLE
Rvic-reassembler explicitly assigns a _FillValue

### DIFF
--- a/actions/make-rvic-grid/DESCRIPTION.md
+++ b/actions/make-rvic-grid/DESCRIPTION.md
@@ -100,19 +100,6 @@ Submit the jobs to the queue.
 Once all the jobs have been submitted and run, you can run `rvic-assembler.py` 
 on the resulting streamflow files to get a grid again.
 
-There is an oversight in `rvic-assembler.py`: it does not assign an explicit
-`_FillValue` attribute to streamflow, and streamflow ends up with the default
-fill value for float variables of `9.96921e+36`, and no explicit `_FillValue`
-attribute. Most netCDF tools seem to make allowances for a default
-unspecified fill value, but the modelmeta indexer does not, and it's
-certainly better to explicitly assign it anyway. So you can either update
-`rvic-assembler.py` before it is next used or use `ncatted` to manually
-assign the fill value attribute, like this:
-```
-ncatted -a _FillValue,streamflow,c,f,9.96921e+36 streamflow_aClimMean_CanESM2_rcp85_r1i1p1_19610101-19901231_peace.nc streamflow.nc
-mv streamflow.nc streamflow_aClimMean_CanESM2_rcp85_r1i1p1_19610101-19901231_peace.nc
-```
-
 ## Helpful commands
 To submit jobs in batches:
  ```

--- a/actions/make-rvic-grid/rvic-reassembler.py
+++ b/actions/make-rvic-grid/rvic-reassembler.py
@@ -18,7 +18,7 @@ all relevant (and some irrelevant) metadata from individual streamflow
 files and the baseflow file, so it makes a start on metadata.
 '''
 
-from netCDF4 import Dataset
+from netCDF4 import Dataset, default_fillvals
 import numpy as np
 import argparse
 import os
@@ -89,14 +89,16 @@ with Dataset(args.domain) as domain:
 # create streamflow variable, copying metadata from an 
 # arbitrary streamflow file
 # some metadata is not applicable, because it only applies to a
-# single grid cell and not the whole hting, but fixing them is
+# single grid cell and not the whole thing, but fixing them is
 # left to update_metadata, not this script.
 # select an arbitrary streamflow output
 with Dataset("{}{}".format(args.streamflow_dir,
                             os.listdir(args.streamflow_dir)[1]), "r") as sf_meta:
+    default_fill = default_fillvals['f4']
     sf_var = output.createVariable("streamflow", 
                                    sf_meta.variables["streamflow"].dtype,
-                                   ("time", "lat", "lon"))
+                                   ("time", "lat", "lon"),
+                                   fill_value=default_fill)
     sf_var.setncatts(sf_meta.variables["streamflow"].__dict__)
     output.setncatts(sf_meta.__dict__)
 


### PR DESCRIPTION
Corrects an error in the `rvic-reassembler.py` script, which is used to assemble the individual routed streamflow at a point into a single large gridded file. 

Previously, no fill value was specified for the `streamflow` variable, and the variable ended up with a default, implicit fillvalue. Some netCDF tools make allowances for this error, but not all of them. Fill values are now explicitly assigned.