### PR TITLE
Add rules-running scripts

### DIFF
--- a/actions/queue-rules-engine/DESCRIPTION.md
+++ b/actions/queue-rules-engine/DESCRIPTION.md
@@ -1,0 +1,16 @@
+# Queue Plan2Adapt Rules Engine
+
+This simple script generates one `pbs` file for each of the plan2adapt regions. Each `pbs` file tells the queue to run the plan2adapt rules engine for its region for the 2020s, 2050s, and 2080s, and saves the result as files named `region_2020`. `region_2050` and `region_2080`.
+
+To use the script, just fill in the variables at the top:
+
+* *connection*: a database DSN string
+* *log_dir*: where job logs should be written to. Directory on storage ending in a /
+* *venv*: a directory on storage where the p2a-rules-engine is installed and a virtual environment named `venv` is set up.
+* *data*: a directory on storage to copy data to when it is finished, ending in a /
+* *ensemble*: database ensemble containing necessary datasets
+
+Then just run the script. You can submit the resulting jobfiles in a batch:
+```
+for file in *.pbs ; do qsub $file ; done
+```

--- a/actions/queue-rules-engine/queue-rules.py
+++ b/actions/queue-rules-engine/queue-rules.py
@@ -1,0 +1,52 @@
+'''Outputs region pbs job files for rules engine calculation'''
+
+# fill in these variables
+connection = "postgresql://use:password@server/database"
+log_dir = "/path/to/logs/"
+venv = "/path/to/p2a-rule-engine/"
+data = "/path/to/data/output/"
+ensemble = "p2a_rules"
+
+climatologies = [2020, 2050, 2080]
+regions = [
+    "bc", "alberni_clayoquot", "boreal_plains", "bulkley_nechako", "capital",
+    "cariboo", "central_coast", "central_kootenay", "central_okanagan",
+    "columbia_shuswap", "comox_valley", "cowichan_valley", "east_kootenay",
+    "fraser_fort_george", "fraser_valley", "greater_vancouver",
+    "kitimat_stikine", "kootenay_boundary", "mt_waddington", "nanaimo",
+    "northern_rockies", "north_okanagan", "okanagan_similkameen",
+    "peace_river", "powell_river", "skeena_queen_charlotte",
+    "squamish_lillooet", "stikine", "strathcona", "sunshine_coast",
+    "thompson_nicola", "interior", "northern", "vancouver_coast",
+    "vancouver_fraser", "vancouver_island", "central_interior",
+    "coast_and_mountains", "georgia_depression", "northern_boreal_mountains",
+    "southern_interior", "southern_interior_mountains", "sub_boreal_mountains",
+    "taiga_plains", "kootenay_/_boundary", "northeast", "omineca", "skeena",
+    "south_coast", "thompson_okanagan", "west_coast"]
+
+def outname(region):
+    return "kootenay_boundary" if region == "kootenay_/_boundary" else region
+
+for region in regions:
+    with open("{}.pbs".format(outname(region)), "w") as outfile:
+        # headers
+        outfile.writelines([
+            "#!/bin/bash\n",
+            "#PBS -l nodes=1:ppn=1\n",
+            "#PBS -l vmem=12000mb\n",
+            "#PBS -l walltime=3:00:00\n",
+            "#PBS -o {}\n".format(log_dir),
+            "#PBS -e {}\n".format(log_dir),
+            "#PBS -m abe\n",
+            "#PBS -N p2a_rules_{}\n".format(region)
+            ])
+        
+        #load environment
+        outfile.write("\n")
+        outfile.write("source {}venv/bin/activate\n".format(venv))
+        
+        for climo in climatologies:
+            outfile.write("python {}scripts/process.py -c {}data/rules.csv -r {} -d {} -e {} -x {} -l CRITICAL > {}_{}.json\n".format(venv, venv, region, climo, ensemble, connection, outname(region), climo))
+            outfile.write("cp {}_{}.json {}\n\n".format(outname(region), climo, data))
+        
+        


### PR DESCRIPTION
This script outputs a `.pbs` file for each plan2adapt region that, when run, calculates the rules for 2020, 2050, and 2080 for that region and saves the results in a `.json` file.