### PR TITLE
Add frost free day calculation script

### DIFF
--- a/actions/frost_free_days/DESCRIPTION.md
+++ b/actions/frost_free_days/DESCRIPTION.md
@@ -1,0 +1,5 @@
+# Frost Free Days
+
+This script is passed an input directory and an output directory. It opens every file in the input directory. If that file has a frost days variable (`fdETCCDI`) it creates a version in the output directory that has frost free days (`ffd`) instead. In other respects, the files are identical, with the same dimensions,  non-frost-related variables, and metadata except variable metadata, and an update to the `history` attribute. The frost free day file will have the same name as the frost day file, but with `ffd` substituted for `fdETCCDI`.
+
+**WARNING**: This script calculates Frost Free Days by subtracting the number of frost days from 365. This is fine for annual datasets, but is incorrect for monthly or seasonal datasets. This script does *not* check the time resolution of a file and is perfectly willing to output garbage for monthly or seasonal datasets. So, for example, if there were 31 frost days in January in a particular wintry location, the script would claim there were somehow 334 frost free days in January.

--- a/actions/frost_free_days/frost_free_days.py
+++ b/actions/frost_free_days/frost_free_days.py
@@ -1,0 +1,60 @@
+''' This script accepts a netCDF file with a frost days (fdETCCDI) variable, and
+outputs an identical file, except the variable has been switched to frost free days (ffd).
+This is so that frost free days can be mapped in ncWMS - unlike our numerical displays, 
+ncWMS can't do the calculation on the fly.'''
+
+from netCDF4 import Dataset
+import argparse
+import os
+import time
+import numpy
+
+parser = argparse.ArgumentParser('Create a frost free days dataset from a frost days dataset')
+parser.add_argument('indir', help='directory containing input files')
+parser.add_argument('outdir', help='directory to output new files to')
+args = parser.parse_args()
+
+for file in os.listdir(args.indir):
+    try:
+        with Dataset("{}/{}".format(args.indir, file), "r") as fdfile:
+            print("Now processing {}".format(file))
+            if 'fdETCCDI' in fdfile.variables:
+                ffd_name = file.replace("fdETCCDI", "ffd")
+                ffdfile = Dataset("{}/{}".format(args.outdir, ffd_name), "w")
+            
+                #copy dimensions
+                print("  Now copying dimensions")
+                for d in fdfile.dimensions:
+                    size = None if fdfile.dimensions[d].isunlimited() else len(fdfile.dimensions[d])
+                    ffdfile.createDimension(d, size)
+                
+                print("  Now copying variables")
+                for v in fdfile.variables:
+                    if v != "fdETCCDI":
+                        ffdfile.createVariable(v, fdfile.variables[v].dtype, fdfile.variables[v].dimensions)
+                        ffdfile.variables[v].setncatts(fdfile.variables[v].__dict__)
+                        ffdfile.variables[v][:] = fdfile.variables[v][:]
+                    else:
+                        print("    Generating Frost Free Days")
+                        fill = fdfile.variables[v].getncattr("_FillValue")
+                        ffdfile.createVariable("ffd", fdfile.variables[v].dtype, fdfile.variables[v].dimensions,
+                                           fill_value=fill)
+                        ffdfile.variables["ffd"].setncattr("standard_name", "ffd")
+                        ffdfile.variables["ffd"].setncattr("long_name", "Frost Free Days")
+                        ffdfile.variables["ffd"].setncattr("units", "days")
+                        ffdfile.variables["ffd"].setncattr("cell_methods", "time: sum within years time: mean over years")
+                        ffdfile.variables["ffd"][:] = (fdfile.variables[v][:] * -1) + 365
+            
+                print("  Now copying global attributes")
+                ffdfile.setncatts(fdfile.__dict__)
+                print("  Now updating history")
+                entry = "{}: frost_free_days {}".format(time.ctime(time.time()), file)
+                ffdfile.history = "{} ".format(entry) + (ffdfile.history if "history" in ffdfile.ncattrs() else "")         
+        
+            else:
+                print("{} is not a frost day datafile")
+        
+    except Exception as e:
+        raise e
+        print(e)
+        print("{} is not a netCDF file".format(file))


### PR DESCRIPTION
This straightforward script was used to generate annual Frost Free Day datafiles to show as maps and in the summary table on plan2adapt. It just takes a climdex `fdETCCDI` dataset (Frost days) and subtracts the number of frost days from 365.