### PR TITLE
Add a watershed size counting script

### DIFF
--- a/actions/watershed-size/DESCRIPTION.md
+++ b/actions/watershed-size/DESCRIPTION.md
@@ -1,0 +1,20 @@
+# Get Watershed Size
+
+This extremely simple script counts the number of cells in an RVIC domain file that are marked as being part of the watershed (that is, they have values greater than 0 on the `mask` variable). 
+
+## Usage
+Run on an RVIC domain file. 
+```bash
+$ python watershed-counter.py /storage/data/projects/hydrology/vic_gen2/input/routing/peace/parameters/domain.rvic.peace.20161018.nc 
+This domain contains 7485 grid cells inside the watershed
+
+$ python watershed-counter.py /storage/data/projects/hydrology/vic_gen2/input/routing/columbia/parameters/domain.pnw.pcic.20170927.nc 
+This domain contains 24113 grid cells inside the watershed
+
+$ python watershed-counter.py /storage/data/projects/hydrology/vic_gen2/input/routing/fraser/parameters/rvic.domain_fraser_v2.nc 
+This domain contains 17731 grid cells inside the watershed
+
+```
+
+## Requirements
+`netcdf4`

--- a/actions/watershed-size/watershed-counter.py
+++ b/actions/watershed-size/watershed-counter.py
@@ -1,0 +1,32 @@
+'''This script accepts a "domain" RVIC file and reports how many grid cells are
+part of the watershed.'''
+
+from netCDF4 import Dataset
+import argparse
+
+parser = argparse.ArgumentParser('Count the number of watershed cells in a domain file')
+parser.add_argument('domain', help='an RVIC domain netCDF')
+
+args = parser.parse_args()
+
+domain = Dataset(args.domain, "r")
+
+variables_needed= ["lat", "lon", "mask"]
+missing_variable = None
+
+for checkvar in variables_needed:
+    if checkvar not in domain.variables:
+        missing_variable = checkvar
+
+if missing_variable:
+    print("{} variable missing from {}".format(missing_variable, args.domain))
+else:
+    watershed_size = 0
+    for y in range(domain.variables["lat"].size):
+        for x in range(domain.variables["lon"].size):
+            mask = domain.variables["mask"][y][x]
+            if mask > 0: # this cell is in the watershed
+                watershed_size += 1
+    print("This domain contains {} grid cells inside the watershed".format(watershed_size))
+    
+domain.close()


### PR DESCRIPTION
Extremely simple script written to help @sum1lim analyze RVIC's performance. 

Reports the number of grid cells in an RVIC domain file with positive values for the `mask` variable. This variable is used to mask out the cells that aren't part of the watershed, so grid cells that aren't masked are part of the watershed as far as RVIC is concerned.

Here's the `mask` variable for the Peace River domain file:
![peace_domain_screenshot](https://user-images.githubusercontent.com/4512605/90687565-e1e68300-e221-11ea-98d4-61c0e670dbd3.png)
