### PR TITLE
Update ncWMS test script to handle dynamic datasets

### DIFF
--- a/actions/test-ncwms-instance/DESCRIPTION.md
+++ b/actions/test-ncwms-instance/DESCRIPTION.md
@@ -17,18 +17,26 @@ HTTP errors.
 Finally it makes a `GetLegendGraphic` request against the server as a whole. `GetLegendGraphic`
 requests *can* be made against individual datasets, but the PDP doesn't do this, so it isn't tested.
 
-## Reuse and Adaptation
-Requests are made in ncWMS 1 format. This script has not been tested with ncWMS 2, but you'd
-probably need to update the `STYLES` parameter to test an ncWMS 2 instance. `default` should
-be a valid value for this attribute for ncWMS 2.
+## NCWMS version
+The `--version` argument can be used to specify ncWMS1 or ncWMS 2 formatted requests, which 
+affects the default pallette names. 
 
+For non-dynamic ncWMS installations, the script will attempt to access each dataset using it
+`unique_id` in the database.
+
+For dynamic ncWMS installation, specify a prefix with the `--prefix` argument, and the script
+will attempt to access the dataset as `prefix/full-filepath`.
+
+
+## Stress Testing
 This script typically takes a couple hours to chew through all the requests;
 it's intended as a shakedown for new ncWMS instances. For routine testing of an existant
 instance, you might want to hit only 10% of the files, or something.
 
-To use as a stress-test, you can change the size of the request image to 1024 x 1024
-(the ncWMS maximum). If running multiple copies of the script at once, randomize the
-file order to prevent ncWMS from just caching the data and getting off easy.
+By default, it requsts a 100x100 pixel map. To use as a stress-test, you can change 
+the size of the request image to 1024 x 1024 (the ncWMS maximum). If running multiple
+copies of the script at once, randomize the file order to prevent ncWMS from just
+caching the data and getting off easy.
 
 ## Usage
 
@@ -38,7 +46,7 @@ python ncWMS-check.py -d postgresql://user:password@server.org:port/database -s 
 
 where: 
 * `-d` argument is the postgres DSN of the modelmeta-formatted database containing the list of files to check
-* `-s` argument is the URL of the ncWMS server, not including the `wms` immediately before the parameters
+* `-s` argument is the URL of the ncWMS server up to but not including the question mark immediately before the parameters
 * `ensemble` is the name of the database ensemble containing the files of interest
 
 Note that the number of errors reported by the script can exceeed the number of files for which errors


### PR DESCRIPTION
Adds new arguments to the ncWMS testing script:

* `--version` to specify ncWMS 1 or 2 (affects palette names)
* `--prefix` to specify a filepath prefix for a dynamic installation

Resolves #34 